### PR TITLE
add feature: add send message function

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,3 +1,4 @@
 pub mod pretty_json_presenter;
+pub mod send_message;
 pub mod show_json;
 pub mod terminal_message_presenter;

--- a/src/presentation/send_message.rs
+++ b/src/presentation/send_message.rs
@@ -1,0 +1,42 @@
+use colored::Colorize;
+
+pub enum RunningStatus {
+    Failed,
+    Notice,
+    Success,
+    Warning,
+}
+
+pub fn send_message(status: RunningStatus, message: &str) {
+    match status {
+        RunningStatus::Failed => {
+            println!("{} {}", "[failed]".red(), message);
+        }
+        RunningStatus::Notice => {
+            println!("{} {}", "[notice]".cyan(), message);
+        }
+        RunningStatus::Success => {
+            println!("{} {}", "[success]".green(), message);
+        }
+        RunningStatus::Warning => {
+            println!("{} {}", "[warning]".yellow(), message);
+        }
+    }
+}
+
+// write tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// test_check_function_showing_status_correctly
+    /// Function must
+    /// - show each status correctly (not raise error for these inputs)
+    fn test_check_function_showing_status_correctly() {
+        send_message(RunningStatus::Failed, "failed message");
+        send_message(RunningStatus::Notice, "notice message");
+        send_message(RunningStatus::Success, "success message");
+        send_message(RunningStatus::Warning, "warning message");
+    }
+}


### PR DESCRIPTION
I am refactoring messaging api. code following is good for our first api, but having trouble.

```rust
use colored::Colorize;

pub struct ConsoleMessenger {
    pub(crate) message: String,
    pub(crate) message_type: MessageType,
}

pub enum MessageType {
    Failed,
    Warning,
    Success,
    Notice,
}

impl ConsoleMessenger {
    pub fn new(message: String, message_type: MessageType) -> ConsoleMessenger {
        ConsoleMessenger {
            message,
            message_type,
        }
    }

    pub fn show_message(&self) {
        match self.message_type {
            MessageType::Failed => {
                println!("{} {}", "[failed]".red(), self.message);
            }
            MessageType::Success => {
                println!("{} {}", "[success]".green(), self.message);
            }
            MessageType::Warning => {
                println!("{} {}", "[warning]".yellow(), self.message);
            }
            MessageType::Notice => {
                println!("{} {}", "[notice]".cyan(), self.message);
            }
        }
    }

    pub fn supply_message(&self) -> String {
        match self.message_type {
            MessageType::Failed => {
                format!("{} {}", "[failed]".red(), self.message)
            }
            MessageType::Success => {
                format!("{} {}", "[success]".green(), self.message)
            }
            MessageType::Warning => {
                format!("{} {}", "[warning]".yellow(), self.message)
            }
            MessageType::Notice => {
                format!("{} {}", "[notice]".cyan(), self.message)
            }
        }
    }
}
```

First of all, this function is too much, because user (developer) has to create struct and run this function. However, we can clear our assignment to use static function. I think it is better for readability.

```rust
use colored::Colorize;

pub enum RunningStatus {
    Failed,
    Notice,
    Success,
    Warning,
}

pub fn send_message(status: RunningStatus, message: &str) {
    match status {
        RunningStatus::Failed => {
            println!("{} {}", "[failed]".red(), message);
        }
        RunningStatus::Notice => {
            println!("{} {}", "[notice]".cyan(), message);
        }
        RunningStatus::Success => {
            println!("{} {}", "[success]".green(), message);
        }
        RunningStatus::Warning => {
            println!("{} {}", "[warning]".yellow(), message);
        }
    }
}
```

To replace, I put above code into our project, then replace functions